### PR TITLE
:test_tube: Configure DNS DHCP Alerts

### DIFF
--- a/k8s-helm-charts/cns-team-monitoring/templates/alertmanager-primary-alertmanagerconfig.yaml
+++ b/k8s-helm-charts/cns-team-monitoring/templates/alertmanager-primary-alertmanagerconfig.yaml
@@ -14,21 +14,29 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   route:
-    receiver: NVVS DevOps
+    receiver: Master Route
     groupBy:
     - 'service'
     groupWait: 30s
     groupInterval: 5m
     repeatInterval: 24h
     routes:
+      - receiver: NVVS DevOps critical
+        groupWait: 10s
+        repeatInterval: 24h
+        matchers:
+          - name: service
+            value: DNS DHCP
+          - name: severity
+            value: critical
       - receiver: NVVS DevOps
         groupWait: 10s
         repeatInterval: 24h
         matchers:
           - name: service
-            value: IMA
+            value: DNS DHCP
           - name: severity
-            value: critical
+            value: warning
       - receiver: Team PKI
         groupWait: 10s
         repeatInterval: 7d
@@ -77,13 +85,39 @@ spec:
             value: Mercury Production
 
   receivers:
-    - name: NVVS DevOps
+    - name: Master Route
       slackConfigs:
         - apiURL:
             key: ima_slack_webhook_url
             name: slack-webhooks
             optional: false
           channel: '#mojo-ima-platform-alerts-dev-preprod'
+          sendResolved: true
+          title: {{`'{{ template "slack.alerts.title" . }}'`}}
+          text: {{`'{{ template "slack.alerts.text" . }}'`}}
+          username: {{`'{{ template "slack.alerts.username" . }}'`}}
+          color: {{`'{{ template "slack.alerts.color" . }}'`}}
+          iconEmoji: {{`'{{ template "slack.alerts.icon_emoji" . }}'`}}
+    - name: NVVS DevOps
+      slackConfigs:
+        - apiURL:
+            key: dhcp_dns_slack_webhook_url
+            name: slack-webhooks
+            optional: false
+          channel: '#mojo-staff-device-dhcp-dns-alerts'
+          sendResolved: true
+          title: {{`'{{ template "slack.alerts.title" . }}'`}}
+          text: {{`'{{ template "slack.alerts.text" . }}'`}}
+          username: {{`'{{ template "slack.alerts.username" . }}'`}}
+          color: {{`'{{ template "slack.alerts.color" . }}'`}}
+          iconEmoji: {{`'{{ template "slack.alerts.icon_emoji" . }}'`}}
+    - name: NVVS DevOps Critical
+      slackConfigs:
+        - apiURL:
+            key: dhcp_dns_slack_webhook_url
+            name: slack-webhooks
+            optional: false
+          channel: '#mojo-staff-device-dhcp-dns-alerts'
           sendResolved: true
           title: {{`'{{ template "slack.alerts.title" . }}'`}}
           text: {{`'{{ template "slack.alerts.text" . }}'`}}

--- a/k8s-helm-charts/cns-team-monitoring/templates/slack-webhooks-secrets.yaml
+++ b/k8s-helm-charts/cns-team-monitoring/templates/slack-webhooks-secrets.yaml
@@ -13,3 +13,4 @@ data:
   network_access_control_pre_production_slack_webhook_url: {{ .Values.alertmanager.alert_rules.network_access_control_pre_production_slack_webhook_url }}
   network_access_control_critical_slack_webhook_url: {{ .Values.alertmanager.alert_rules.network_access_control_critical_slack_webhook_url }}
   pagerduty_routing_key: {{ .Values.alertmanager.alert_rules.pagerduty_routing_key }}
+  dhcp_dns_slack_webhook_url: {{ .Values.alertmanager.alert_rules.dhcp_dns_slack_webhook_url }}

--- a/k8s-helm-charts/cns-team-monitoring/values.yaml
+++ b/k8s-helm-charts/cns-team-monitoring/values.yaml
@@ -11,6 +11,7 @@ alertmanager:
     password: ""
   alert_rules:
     ima_slack_webhook_url: ""
+    dhcp_dns_slack_webhook_url: ""
     pagerduty_routing_key: ""
     certificate_services_slack_webhook_url: ""
     networks_slack_webhook_url: ""

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -49,6 +49,7 @@ set_variables() {
   alertmanager_smtp_password=`aws ssm get-parameter --name "/codebuild/pttp-ci-ima-pipeline/production/smtp_password" --with-decryption  --query Parameter.Value --output text`
   pagerduty_routing_key=`aws ssm get-parameter --name "/codebuild/pttp-ci-ima-pipeline/production/pagerduty_routing_key" --with-decryption --query Parameter.Value --output text`
   ima_slack_webhook_url=`aws ssm get-parameter --name "/codebuild/pttp-ci-datasource-config-pipeline/development/mojo-ima-platform-alerts_slack_webhook_url" --with-decryption --query Parameter.Value --output text`
+  dhcp_dns_slack_webhook_url=`aws ssm get-parameter --name "/codebuild/pttp-ci-datasource-config-pipeline/production/mojo-staff-device-dhcp-dns-alerts_slackwebhook" --with-decryption --query Parameter.Value --output text`
   certificate_services_slack_webhook_url=`aws ssm get-parameter --name "/codebuild/pttp-ci-ima-pipeline/production/slack_webhook_url/pki-alerts" --with-decryption --query Parameter.Value --output text`
   networks_slack_webhook_url=`aws ssm get-parameter --name "/codebuild/pttp-ci-ima-pipeline/production/slack_webhook_url/mojdt-network-alerts" --with-decryption --query Parameter.Value --output text`
   ost_slack_webhook_url=`aws ssm get-parameter --name "/codebuild/pttp-ci-datasource-config-pipeline/production/ost_slack_webhook_url" --with-decryption --query Parameter.Value --output text`
@@ -254,6 +255,7 @@ deploy_cns_team_monitoring() {
     --set cloudwatchExporterPreProductionArn=$cloudwatch_exporter_pre_production_iam_role_arn \
     --set alertmanager.alert_rules.pagerduty_routing_key=`base64_encode $pagerduty_routing_key` \
     --set alertmanager.alert_rules.ima_slack_webhook_url=`base64_encode $ima_slack_webhook_url` \
+    --set alertmanager.alert_rules.dhcp_dns_slack_webhook_url=`base64_encode $dhcp_dns_slack_webhook_url` \
     --set alertmanager.alert_rules.certificate_services_slack_webhook_url=`base64_encode $certificate_services_slack_webhook_url` \
     --set alertmanager.alert_rules.networks_slack_webhook_url=`base64_encode $networks_slack_webhook_url` \
     --set alertmanager.alert_rules.ost_slack_webhook_url=`base64_encode $ost_slack_webhook_url` \
@@ -266,15 +268,15 @@ main() {
   set_variables
   set_kubeconfig
   deploy_kube-prometheus-stack
-  deploy_thanos_stack
-  deploy_shared_resources_helm_chart
-  annotate_service_account
-  deploy_aws_lb_controller
-  deploy_aws_efs_csi_driver
-  deploy_aws_ebs_csi_driver
-  deploy_external_dns
-  deploy_ingress_nginx
-  deploy_grafana
+  # deploy_thanos_stack
+  # deploy_shared_resources_helm_chart
+  # annotate_service_account
+  # deploy_aws_lb_controller
+  # deploy_aws_efs_csi_driver
+  # deploy_aws_ebs_csi_driver
+  # deploy_external_dns
+  # deploy_ingress_nginx
+  # deploy_grafana
   deploy_cns_team_monitoring
 }
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -268,15 +268,15 @@ main() {
   set_variables
   set_kubeconfig
   deploy_kube-prometheus-stack
-  # deploy_thanos_stack
-  # deploy_shared_resources_helm_chart
-  # annotate_service_account
-  # deploy_aws_lb_controller
-  # deploy_aws_efs_csi_driver
-  # deploy_aws_ebs_csi_driver
-  # deploy_external_dns
-  # deploy_ingress_nginx
-  # deploy_grafana
+  deploy_thanos_stack
+  deploy_shared_resources_helm_chart
+  annotate_service_account
+  deploy_aws_lb_controller
+  deploy_aws_efs_csi_driver
+  deploy_aws_ebs_csi_driver
+  deploy_external_dns
+  deploy_ingress_nginx
+  deploy_grafana
   deploy_cns_team_monitoring
 }
 


### PR DESCRIPTION
This PR updates AlertManager with a new slack webhook for DNS DHCP slack channel alerts as well as splitting out critical alerts sent to PagerDuty. 