### PR TITLE
Increase-DHCP-Error-Threshold

### DIFF
--- a/k8s-helm-charts/cns-team-monitoring/templates/dns-dhcp-alert-rules.yaml
+++ b/k8s-helm-charts/cns-team-monitoring/templates/dns-dhcp-alert-rules.yaml
@@ -66,7 +66,7 @@ spec:
         description: KEA DHCP Failed leases is greater than 10. The current value is {{ "{{ $value }}" }}
         grafana_dashboard_url: https://monitoring-alerting.staff.service.justice.gov.uk/d/cEwjsH1Gk/kea-dhcp-metrics
     - alert: DHCP KEA Server Alert
-      expr: aws_kea_dhcp_error_sum > 10 or aws_kea_dhcp_fatal_sum > 10
+      expr: aws_kea_dhcp_error_sum > 100 or aws_kea_dhcp_fatal_sum > 100
       for: 7m
       labels:
         severity: critical


### PR DESCRIPTION
Increase DHCP error threshold while Empty DUIDs error's are being received. revert PR once error's stop.