### PR TITLE
:wrench: Update Cloudwatch Role logic

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -44,6 +44,7 @@ provider "registry.terraform.io/hashicorp/tls" {
   version = "4.0.4"
   hashes = [
     "h1:Wd3RqmQW60k2QWPN4sK5CtjGuO1d+CRNXgC+D4rKtXc=",
+    "h1:pe9vq86dZZKCm+8k1RhzARwENslF3SXb9ErHbQfgjXU=",
     "zh:23671ed83e1fcf79745534841e10291bbf34046b27d6e68a5d0aab77206f4a55",
     "zh:45292421211ffd9e8e3eb3655677700e3c5047f71d8f7650d2ce30242335f848",
     "zh:59fedb519f4433c0fdb1d58b27c210b27415fddd0cd73c5312530b4309c088be",

--- a/modules/eks/iam.tf
+++ b/modules/eks/iam.tf
@@ -440,11 +440,21 @@ resource "aws_iam_policy" "other_cloudwatch_exporter_role_allow_assume_policy" {
   ]
 }
 POLICY
+
+  depends_on = [
+    aws_iam_role.cloudwatch_exporter_development,
+    aws_iam_role.cloudwatch_exporter_pre_production,
+  ]
 }
 
 resource "aws_iam_role_policy_attachment" "other_cloudwatch_exporter_allow_assume_IAMPolicy" {
   policy_arn = aws_iam_policy.other_cloudwatch_exporter_role_allow_assume_policy.arn
   role       = aws_iam_role.cloudwatch_exporter.name
+
+  depends_on = [
+    aws_iam_role.cloudwatch_exporter_development,
+    aws_iam_role.cloudwatch_exporter_pre_production,
+  ]
 }
 
 # Prepare a policy document that can be used by iam roles created in other aws accounts that allow cloudwatch exporter to assume the roles

--- a/modules/eks/iam.tf
+++ b/modules/eks/iam.tf
@@ -435,7 +435,7 @@ resource "aws_iam_policy" "other_cloudwatch_exporter_role_allow_assume_policy" {
           "Action": "sts:AssumeRole",
           "Resource": [
               "${terraform.workspace != "development" ? aws_iam_role.cloudwatch_exporter_development[0].arn : ""}",
-              "${terraform.workspace != "pre-production" ? aws_iam_role.cloudwatch_exporter_pre_production.arn : ""}"
+              "${terraform.workspace != "pre-production" ? aws_iam_role.cloudwatch_exporter_pre_production[0].arn : ""}"
           ]
       }
   ]
@@ -508,6 +508,7 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_exporter_IAMPolicy_develop
 # IAM role for Cloudwatch Exporter in pre-production aws account
 
 resource "aws_iam_role" "cloudwatch_exporter_pre_production" {
+  count              = terraform.workspace == "pre-production" ? 0 : 1
   assume_role_policy = data.aws_iam_policy_document.cloudwatch_exporter_assume_role_policy_other_aws_accounts.json
   name               = "${var.prefix}-CloudwatchExporter"
 
@@ -517,6 +518,7 @@ resource "aws_iam_role" "cloudwatch_exporter_pre_production" {
 }
 
 resource "aws_iam_policy" "cloudwatch_exporter_iam_policy_pre_production" {
+  count       = terraform.workspace == "pre-production" ? 0 : 1
   name        = "${var.prefix}-CloudwatchExporterIAMPolicy"
   path        = "/"
   description = "IAM role policy for Cloudwatch Exporter in EKS Cluster for ${var.prefix}"
@@ -529,8 +531,9 @@ resource "aws_iam_policy" "cloudwatch_exporter_iam_policy_pre_production" {
 }
 
 resource "aws_iam_role_policy_attachment" "cloudwatch_exporter_IAMPolicy_pre_production" {
-  policy_arn = aws_iam_policy.cloudwatch_exporter_iam_policy_pre_production.arn
-  role       = aws_iam_role.cloudwatch_exporter_pre_production.name
+  count      = terraform.workspace == "pre-production" ? 0 : 1
+  policy_arn = aws_iam_policy.cloudwatch_exporter_iam_policy_pre_production[0].arn
+  role       = aws_iam_role.cloudwatch_exporter_pre_production[0].name
 
   provider = aws.pre_production
 }

--- a/modules/eks/iam.tf
+++ b/modules/eks/iam.tf
@@ -433,7 +433,7 @@ resource "aws_iam_policy" "other_cloudwatch_exporter_role_allow_assume_policy" {
           "Effect": "Allow",
           "Action": "sts:AssumeRole",
           "Resource": [
-              "${aws_iam_role.cloudwatch_exporter_development.arn}",
+              "${aws_iam_role.cloudwatch_exporter_development[0].arn}",
               "${aws_iam_role.cloudwatch_exporter_pre_production.arn}"
           ]
       }

--- a/modules/eks/iam.tf
+++ b/modules/eks/iam.tf
@@ -434,8 +434,8 @@ resource "aws_iam_policy" "other_cloudwatch_exporter_role_allow_assume_policy" {
           "Effect": "Allow",
           "Action": "sts:AssumeRole",
           "Resource": [
-              "${terraform.workspace != "development" ? aws_iam_role.cloudwatch_exporter_development[0].arn : null}",
-              "${terraform.workspace != "pre-production" ? aws_iam_role.cloudwatch_exporter_pre_production.arn : null}"
+              "${terraform.workspace != "development" ? aws_iam_role.cloudwatch_exporter_development[0].arn : ""}",
+              "${terraform.workspace != "pre-production" ? aws_iam_role.cloudwatch_exporter_pre_production.arn : ""}"
           ]
       }
   ]

--- a/modules/eks/iam.tf
+++ b/modules/eks/iam.tf
@@ -464,6 +464,7 @@ data "aws_iam_policy_document" "cloudwatch_exporter_assume_role_policy_other_aws
 # IAM role for Cloudwatch Exporter in development aws account
 
 resource "aws_iam_role" "cloudwatch_exporter_development" {
+  count              = terraform.workspace == "development" ? 0 : 1
   assume_role_policy = data.aws_iam_policy_document.cloudwatch_exporter_assume_role_policy_other_aws_accounts.json
   name               = "${var.prefix}-CloudwatchExporter"
 
@@ -473,6 +474,7 @@ resource "aws_iam_role" "cloudwatch_exporter_development" {
 }
 
 resource "aws_iam_policy" "cloudwatch_exporter_iam_policy_development" {
+  count       = terraform.workspace == "development" ? 0 : 1
   name        = "${var.prefix}-CloudwatchExporterIAMPolicy"
   path        = "/"
   description = "IAM role policy for Cloudwatch Exporter in EKS Cluster for ${var.prefix}"
@@ -485,8 +487,9 @@ resource "aws_iam_policy" "cloudwatch_exporter_iam_policy_development" {
 }
 
 resource "aws_iam_role_policy_attachment" "cloudwatch_exporter_IAMPolicy_development" {
-  policy_arn = aws_iam_policy.cloudwatch_exporter_iam_policy_development.arn
-  role       = aws_iam_role.cloudwatch_exporter_development.name
+  count      = terraform.workspace == "development" ? 0 : 1
+  policy_arn = aws_iam_policy.cloudwatch_exporter_iam_policy_development[0].arn
+  role       = aws_iam_role.cloudwatch_exporter_development[0].name
 
   provider = aws.development
 }

--- a/modules/eks/iam.tf
+++ b/modules/eks/iam.tf
@@ -418,6 +418,7 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_exporter_IAMPolicy" {
 }
 
 # Create and attach a policy to the cloudwatch exporter iam role that allows Cloudwatch exporter to assume roles in other AWS accouts to scrape cloudwatch metrics
+# Depends on added to avoid infinite loop of depencies
 
 resource "aws_iam_policy" "other_cloudwatch_exporter_role_allow_assume_policy" {
   name        = "other_cloudwatch_exporter_role_allow_assume_policy"

--- a/modules/eks/iam.tf
+++ b/modules/eks/iam.tf
@@ -433,8 +433,8 @@ resource "aws_iam_policy" "other_cloudwatch_exporter_role_allow_assume_policy" {
           "Effect": "Allow",
           "Action": "sts:AssumeRole",
           "Resource": [
-              "${aws_iam_role.cloudwatch_exporter_development[0].arn}",
-              "${aws_iam_role.cloudwatch_exporter_pre_production.arn}"
+              terraform.workspace != "development" ? "${aws_iam_role.cloudwatch_exporter_development[0].arn}" : "",
+              terraform.workspace != "pre-production" ? "${aws_iam_role.cloudwatch_exporter_pre_production.arn}" : ""
           ]
       }
   ]

--- a/modules/eks/iam.tf
+++ b/modules/eks/iam.tf
@@ -433,7 +433,7 @@ resource "aws_iam_policy" "other_cloudwatch_exporter_role_allow_assume_policy" {
           "Effect": "Allow",
           "Action": "sts:AssumeRole",
           "Resource": [
-              "${terraform.workspace != "development" ? aws_iam_role.cloudwatch_exporter_development[0].arn : null }",
+              "${terraform.workspace != "development" ? aws_iam_role.cloudwatch_exporter_development[0].arn : null}",
               "${terraform.workspace != "pre-production" ? aws_iam_role.cloudwatch_exporter_pre_production.arn : null}"
           ]
       }

--- a/modules/eks/iam.tf
+++ b/modules/eks/iam.tf
@@ -433,8 +433,8 @@ resource "aws_iam_policy" "other_cloudwatch_exporter_role_allow_assume_policy" {
           "Effect": "Allow",
           "Action": "sts:AssumeRole",
           "Resource": [
-              terraform.workspace != "development" ? "${aws_iam_role.cloudwatch_exporter_development[0].arn}" : "",
-              terraform.workspace != "pre-production" ? "${aws_iam_role.cloudwatch_exporter_pre_production.arn}" : ""
+              "${terraform.workspace != "development" ? aws_iam_role.cloudwatch_exporter_development[0].arn : null }",
+              "${terraform.workspace != "pre-production" ? aws_iam_role.cloudwatch_exporter_pre_production.arn : null}"
           ]
       }
   ]

--- a/modules/eks/outputs.tf
+++ b/modules/eks/outputs.tf
@@ -47,7 +47,7 @@ output "cloudwatch_exporter_iam_role_arn" {
 }
 
 output "cloudwatch_exporter_development_iam_role_arn" {
-  value = aws_iam_role.cloudwatch_exporter_development[0].arn
+  value = aws_iam_role.cloudwatch_exporter_development != null aws_iam_role.cloudwatch_exporter_development[0].arn : ""
 }
 
 output "cloudwatch_exporter_pre_production_iam_role_arn" {

--- a/modules/eks/outputs.tf
+++ b/modules/eks/outputs.tf
@@ -47,7 +47,7 @@ output "cloudwatch_exporter_iam_role_arn" {
 }
 
 output "cloudwatch_exporter_development_iam_role_arn" {
-  value = aws_iam_role.cloudwatch_exporter_development[count.index].arn
+  value = aws_iam_role.cloudwatch_exporter_development[0].arn
 }
 
 output "cloudwatch_exporter_pre_production_iam_role_arn" {

--- a/modules/eks/outputs.tf
+++ b/modules/eks/outputs.tf
@@ -47,7 +47,7 @@ output "cloudwatch_exporter_iam_role_arn" {
 }
 
 output "cloudwatch_exporter_development_iam_role_arn" {
-  value = aws_iam_role.cloudwatch_exporter_development.arn
+  value = aws_iam_role.cloudwatch_exporter_development[0].arn
 }
 
 output "cloudwatch_exporter_pre_production_iam_role_arn" {

--- a/modules/eks/outputs.tf
+++ b/modules/eks/outputs.tf
@@ -47,7 +47,7 @@ output "cloudwatch_exporter_iam_role_arn" {
 }
 
 output "cloudwatch_exporter_development_iam_role_arn" {
-  value = aws_iam_role.cloudwatch_exporter_development != null aws_iam_role.cloudwatch_exporter_development[0].arn : ""
+  value = aws_iam_role.cloudwatch_exporter_development != null ? aws_iam_role.cloudwatch_exporter_development[0].arn : ""
 }
 
 output "cloudwatch_exporter_pre_production_iam_role_arn" {

--- a/modules/eks/outputs.tf
+++ b/modules/eks/outputs.tf
@@ -51,7 +51,7 @@ output "cloudwatch_exporter_development_iam_role_arn" {
 }
 
 output "cloudwatch_exporter_pre_production_iam_role_arn" {
-  value = aws_iam_role.cloudwatch_exporter_pre_production.arn
+  value = aws_iam_role.cloudwatch_exporter_pre_production != [] ? aws_iam_role.cloudwatch_exporter_pre_production[0].arn : ""
 }
 
 output "db_endpoint" {

--- a/modules/eks/outputs.tf
+++ b/modules/eks/outputs.tf
@@ -47,7 +47,7 @@ output "cloudwatch_exporter_iam_role_arn" {
 }
 
 output "cloudwatch_exporter_development_iam_role_arn" {
-  value = aws_iam_role.cloudwatch_exporter_development != null ? aws_iam_role.cloudwatch_exporter_development[0].arn : ""
+  value = aws_iam_role.cloudwatch_exporter_development != [] ? aws_iam_role.cloudwatch_exporter_development[0].arn : ""
 }
 
 output "cloudwatch_exporter_pre_production_iam_role_arn" {

--- a/modules/eks/outputs.tf
+++ b/modules/eks/outputs.tf
@@ -47,7 +47,7 @@ output "cloudwatch_exporter_iam_role_arn" {
 }
 
 output "cloudwatch_exporter_development_iam_role_arn" {
-  value = aws_iam_role.cloudwatch_exporter_development[0].arn
+  value = aws_iam_role.cloudwatch_exporter_development[count.index].arn
 }
 
 output "cloudwatch_exporter_pre_production_iam_role_arn" {


### PR DESCRIPTION
This PR update logic by which Cloudwatch roles are created using terraform, without this logic a deployment to `development` fails.