### PR TITLE
:wrench: Remove PagerDuty Alerts for Certificate warnings

### DIFF
--- a/k8s-helm-charts/cns-team-monitoring/templates/alertmanager-primary-alertmanagerconfig.yaml
+++ b/k8s-helm-charts/cns-team-monitoring/templates/alertmanager-primary-alertmanagerconfig.yaml
@@ -141,10 +141,6 @@ spec:
           username: {{`'{{ template "slack.alerts.username" . }}'`}}
           color: {{`'{{ template "slack.alerts.color" . }}'`}}
           iconEmoji: {{`'{{ template "slack.alerts.icon_emoji" . }}'`}}
-      pagerdutyConfigs:
-        - routingKey:
-            key: pagerduty_routing_key
-            name: slack-webhooks
     - name: Team IGS
       slackConfigs:
         - apiURL:


### PR DESCRIPTION
Certificate expiring warnings are not required to be sent to PagerDuty for out-of-hours action. This PR will remove the PagerDuty config and only send the alert to the 'mojo-staff-certificate-services' slack channel. 