### PR TITLE
Scrape New NACS Production Metrics

### DIFF
--- a/k8s-helm-charts/cns-team-monitoring/templates/cloudwatch-metrics/_production-metrics-custom.tpl
+++ b/k8s-helm-charts/cns-team-monitoring/templates/cloudwatch-metrics/_production-metrics-custom.tpl
@@ -434,6 +434,16 @@
     nilToZero: true
     period: 300
     length: 300
+  - name: "reject Ethernet"
+    statistics: [Sum]
+    nilToZero: true
+    period: 300
+    length: 300
+  - name: "reject Wireless-802.11"
+    statistics: [Sum]
+    nilToZero: true
+    period: 300
+    length: 300
 - namespace: GP_GATEWAY_VMseries
   name: "GP_GATEWAY_VMseries"
   regions: [eu-west-2]


### PR DESCRIPTION
This PR updates Cloudwatch Exporter to scrape the new NACS rejects metrics.