### PR TITLE
:stethoscope: NACS Dashboard Update Time Range

### DIFF
--- a/k8s-helm-charts/cns-team-monitoring/templates/network-access-control-grafana-dashboard.yaml
+++ b/k8s-helm-charts/cns-team-monitoring/templates/network-access-control-grafana-dashboard.yaml
@@ -1660,7 +1660,7 @@ data:
           "type": "timeseries"
         }
       ],
-      "refresh": false,
+      "refresh": "1m",
       "schemaVersion": 38,
       "style": "dark",
       "tags": [],
@@ -1668,7 +1668,7 @@ data:
         "list": [
           {
             "current": {
-              "selected": false,
+              "selected": true,
               "text": "Production",
               "value": "{{ .Values.production_account_id }}"
             },
@@ -1702,13 +1702,13 @@ data:
         ]
       },
       "time": {
-        "from": "2023-05-03T14:01:02.640Z",
-        "to": "2023-05-03T14:53:31.413Z"
+        "from": "now-1h",
+        "to": "now"
       },
       "timepicker": {},
       "timezone": "",
       "title": "Network Access Control",
       "uid": "CFhQiFxnk",
-      "version": 1,
+      "version": 2,
       "weekStart": ""
     }


### PR DESCRIPTION
This PR sets the dashboard to load data for the last hour rather than a specific time range and also adds a 1m refresh.

before: 
![image](https://user-images.githubusercontent.com/41325732/236431991-ba09a627-e3f6-4ff5-98d3-18ed6c61e2df.png)

after: 
![image](https://user-images.githubusercontent.com/41325732/236432113-d375a49f-50d7-4969-b396-3e63ef4ff2d8.png)
