### PR TITLE
:wrench: Added a new metric called "EAP TLS OCSP Error" for mojo nac-…

### DIFF
--- a/k8s-helm-charts/cns-team-monitoring/templates/cloudwatch-metrics/_production-metrics-custom.tpl
+++ b/k8s-helm-charts/cns-team-monitoring/templates/cloudwatch-metrics/_production-metrics-custom.tpl
@@ -444,6 +444,11 @@
     nilToZero: true
     period: 300
     length: 300
+  - name: "EAP TLS OCSP Error"
+    statistics: [Sum]
+    nilToZero: true
+    period: 300
+    length: 300
 - namespace: GP_GATEWAY_VMseries
   name: "GP_GATEWAY_VMseries"
   regions: [eu-west-2]


### PR DESCRIPTION
…request

- added a custom metric to visualise OCSP failure metric on the grafana dashboard 