### PR TITLE
added EAP TLS OCSP Error metric to the NAC Dashboard

### DIFF
--- a/k8s-helm-charts/cns-team-monitoring/templates/dns-dhcp-alert-rules.yaml
+++ b/k8s-helm-charts/cns-team-monitoring/templates/dns-dhcp-alert-rules.yaml
@@ -66,15 +66,15 @@ spec:
         description: KEA DHCP Failed leases is greater than 10. The current value is {{ "{{ $value }}" }}
         grafana_dashboard_url: https://monitoring-alerting.staff.service.justice.gov.uk/d/cEwjsH1Gk/kea-dhcp-metrics
     - alert: DHCP KEA Server Alert
-      expr: aws_kea_dhcp_error_sum{account_id="{{ .Values.production_account_id }}" } > 100 or aws_kea_dhcp_fatal_sum{account_id="{{ .Values.production_account_id }}" } > 100
+      expr: aws_kea_dhcp_error_sum{account_id="{{ .Values.production_account_id }}" } > 150 or aws_kea_dhcp_fatal_sum{account_id="{{ .Values.production_account_id }}" } > 150
       for: 7m
       labels:
         severity: critical
         service: DNS DHCP
         namespace: {{ .Release.Namespace }}
       annotations:
-        summary: DHCP KEA Server Alert ERROR or FATAL > 10
-        description: The server alert ERROR or FATAL is greater than 10. The current value is {{ "{{ $value }}" }}
+        summary: DHCP KEA Server Alert ERROR or FATAL > 150
+        description: The server alert ERROR or FATAL is greater than 150. The current value is {{ "{{ $value }}" }}
         grafana_dashboard_url: https://monitoring-alerting.staff.service.justice.gov.uk/d/cEwjsH1Gk/kea-dhcp-metrics
     - alert: DHCP RDS CPU Alert
       expr:  aws_rds_cpuutilization_average{dimension_DBInstanceIdentifier="staff-device-production-dhcp-db"} > 60

--- a/k8s-helm-charts/cns-team-monitoring/templates/network-access-control-grafana-dashboard.yaml
+++ b/k8s-helm-charts/cns-team-monitoring/templates/network-access-control-grafana-dashboard.yaml
@@ -1658,8 +1658,102 @@ data:
           ],
           "title": "RDS IOPS",
           "type": "timeseries"
+        },
+         {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "This panels displays all the errors related EAP TLS OCSP Checks.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 56
+      },
+      "id": 39,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "aws_mojo_nac_requests_eap_tls_ocsp_error_sum{account_id=\"$account_id\"}",
+          "instant": true,
+          "key": "Q-a7937d13-19ce-45ce-9e53-c09413a2ee59-0",
+          "range": true,
+          "refId": "A"
         }
       ],
+      "title": "EAP TLS OCSP Error",
+      "type": "timeseries"
+    }
+    ],
       "refresh": "1m",
       "schemaVersion": 38,
       "style": "dark",


### PR DESCRIPTION
changed DHCP server error sum alert threshold to 150 temporarily to allow us time to investigate the errors we are getting

- DHCP discover packet from unknown IP
- Missing DUIDs

with a view to create alerts based on specific metric rather then from a metric that capture ALL errors and alerting based on that metric