### PR TITLE
Updated bucket & dynamo name for Terraform state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ terraform.tfstate
 *.tfvars
 *.tfstate.*
 .infracost/
+.terraform-version

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
-    bucket         = "staff-infrastructure-monitoring-cluster-tf-state"
-    dynamodb_table = "staff-infrastructure-monitoring-cluster-tf-lock-table"
+    bucket         = "staff-ci-infrastructure-client-monitoring-cluster-tf-state"
+    dynamodb_table = "staff-ci-infrastructure-client-monitoring-cluster-tf-lock-table"
     region         = "eu-west-2"
   }
 }


### PR DESCRIPTION
The s3 bucket and dyanmo DB tables was not created in IAC in the shared services AWS account. To resolve this we created a new S3 bucket and dynmo DB table within IAC and copied the contents of the old IAC bucket to the new bucket