### PR TITLE
Amended directory for dependabot container scan

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,6 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "docker"
-    directory: "/"
+    directory: "k8s-helm-charts/cns-team-monitoring/templates"
     schedule:
       interval: "daily"


### PR DESCRIPTION
- Amended directory for dependabot container scan - this will allow us to see outdated versions of the pinned container in that folder. 