### PR TITLE
Nd 430 - fix missing env values during helm deployment

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -6,6 +6,7 @@
 # - Nginx Ingress Controller
 
 set -e
+source .env
 
 ORANGE='\033[1;33m'
 PURPLE='\033[1;35m'

--- a/scripts/generate-env-file.sh
+++ b/scripts/generate-env-file.sh
@@ -89,9 +89,6 @@ cat << EOF > ./.env
 # then run "make init"
 
 
-export AWS_PROFILE=mojo-shared-services-cli
-export AWS_VAULT_PROFILE=mojo-shared-services-cli
-
 ### ${ENV} ###
 export ENV=${ENV}
 export TF_VAR_env=${ENV}


### PR DESCRIPTION
Use .env during local dev deployments