### PR TITLE
condition the use of .env

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -6,7 +6,14 @@
 # - Nginx Ingress Controller
 
 set -e
-source .env
+
+# Check if the .env file exists
+if [ -f .env ]; then
+  # If it exists, source the .env file
+  source .env
+else
+  echo ".env file not found. Skipping..."
+fi
 
 ORANGE='\033[1;33m'
 PURPLE='\033[1;35m'


### PR DESCRIPTION
.env file is used by local developers but it is not used in GitHub actions as the variables / secrets are passed in differently. This conditional change makes providing a .env file optional to the deploy script.