### PR TITLE
Nd 485 smtp metric

### DIFF
--- a/k8s-helm-charts/cns-team-monitoring/templates/alertmanager-primary-alertmanagerconfig.yaml
+++ b/k8s-helm-charts/cns-team-monitoring/templates/alertmanager-primary-alertmanagerconfig.yaml
@@ -107,6 +107,14 @@ spec:
             value: NACS Certificate Expiry Warning
           - name: severity
             value: warning
+      - receiver: NVVS DevOps Critical
+        groupWait: 10s
+        repeatInterval: 7d
+        matchers:
+          - name: service
+            value: SMTP Relay
+          - name: severity
+            value: critical
 
   receivers:
     - name: Master Route

--- a/k8s-helm-charts/cns-team-monitoring/templates/cloudwatch-metrics/_production-metrics-custom.tpl
+++ b/k8s-helm-charts/cns-team-monitoring/templates/cloudwatch-metrics/_production-metrics-custom.tpl
@@ -449,6 +449,21 @@
     nilToZero: true
     period: 300
     length: 300
+- namespace: smtp-relay-postfix-exporter
+  name: "smtp-relay-postfix-exporter"
+  regions: [eu-west-2]
+  roles:
+    - roleArn: {{ .Values.cloudwatchExporterProductionArn }}
+    - roleArn: {{ .Values.cloudwatchExporterPreProductionArn }}
+    - roleArn: {{ .Values.cloudwatchExporterDevelopmentArn }}
+    - roleArn: {{ .Values.cloudwatchExporterPkiArn }}
+  metrics:
+  - name: "FailedToScrape"
+    statistics: [Sum]
+    nilToZero: true
+    period: 300
+    length: 300
+
 - namespace: GP_GATEWAY_VMseries
   name: "GP_GATEWAY_VMseries"
   regions: [eu-west-2]

--- a/k8s-helm-charts/cns-team-monitoring/templates/smtp-relay-alert-rules.yaml
+++ b/k8s-helm-charts/cns-team-monitoring/templates/smtp-relay-alert-rules.yaml
@@ -65,3 +65,14 @@ spec:
           summary: SMTP Rate of change in deferred status count is above 0.0200
           description: The SMTP deferred rate of change has increased above 0.0200
           grafana_dashboard_url: https://monitoring-alerting.staff.service.justice.gov.uk/d/h36Havfik/postfix
+      - alert: SMTP Postfix Exporter Failed to Scrape Metric
+        expr: aws_smtp_relay_postfix_exporter_failed_to_scrape_sum{account_id="{{ .Values.production_account_id }}" } > 1
+        for: 5m
+        labels:
+          severity: critical
+          service: SMTP Relay
+          namespace: {{ .Release.Namespace }}
+        annotations:
+          summary: SMTP Postfix Exporter has failed to Scrape logs from SMTP Server
+          description: The SMTP Postfix Exporter FailedToScrape Metric SUM is > 1
+          grafana_dashboard_url: https://monitoring-alerting.staff.service.justice.gov.uk/d/h36Havfik/postfix


### PR DESCRIPTION
- Adds Custom metric for postfix exporter 'FailedToScrape'
- adds alerting rules if there is an error sum > 1 in 5 mins 
- Updated SMTP Production service alarm route to go to DEVOPS critical SLACK Channel