### PR TITLE
removing DHCP API target for dev and prep as per ND-452

### DIFF
--- a/k8s-values/values.kube-prometheus-stack.yaml
+++ b/k8s-values/values.kube-prometheus-stack.yaml
@@ -34,8 +34,8 @@ prometheus:
           module: [default]
         static_configs:
           - targets:
-              - https://dhcp-dns-admin.dev.staff.service.justice.gov.uk/api/dhcp-stats
-              - https://dhcp-dns-admin.prep.staff.service.justice.gov.uk/api/dhcp-stats
+#              - https://dhcp-dns-admin.dev.staff.service.justice.gov.uk/api/dhcp-stats
+#              - https://dhcp-dns-admin.prep.staff.service.justice.gov.uk/api/dhcp-stats
               - https://dhcp-dns-admin.staff.service.justice.gov.uk/api/dhcp-stats
         relabel_configs:
           - source_labels: [__address__]

--- a/k8s-values/values.kube-prometheus-stack.yaml
+++ b/k8s-values/values.kube-prometheus-stack.yaml
@@ -34,8 +34,8 @@ prometheus:
           module: [default]
         static_configs:
           - targets:
-#              - https://dhcp-dns-admin.dev.staff.service.justice.gov.uk/api/dhcp-stats
-#              - https://dhcp-dns-admin.prep.staff.service.justice.gov.uk/api/dhcp-stats
+              #              - https://dhcp-dns-admin.dev.staff.service.justice.gov.uk/api/dhcp-stats
+              #              - https://dhcp-dns-admin.prep.staff.service.justice.gov.uk/api/dhcp-stats
               - https://dhcp-dns-admin.staff.service.justice.gov.uk/api/dhcp-stats
         relabel_configs:
           - source_labels: [__address__]


### PR DESCRIPTION
- Removing the DHCP API target fro dev and preprod as it not required and alerting unnecessarily 