### PR TITLE
changed eks version in terraform after upgrading using command line

### DIFF
--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -1,6 +1,6 @@
 resource "aws_eks_cluster" "this" {
   name                      = var.prefix
-  version                   = "1.26"
+  version                   = "1.27"
   role_arn                  = aws_iam_role.cluster.arn
   enabled_cluster_log_types = ["api", "audit"]
 


### PR DESCRIPTION
EKS upgrade was done using the command line - this change is to just reflect that in the terraform code to allow future deployments.