### PR TITLE
corrected engine version to match what is in production

### DIFF
--- a/modules/eks/rds.tf
+++ b/modules/eks/rds.tf
@@ -5,7 +5,7 @@ resource "aws_db_instance" "this" {
   storage_type                = "gp3"
   engine                      = "postgres"
   apply_immediately           = true
-  engine_version              = "14.12"
+  engine_version              = "14.13"
   auto_minor_version_upgrade  = true
   allow_major_version_upgrade = false
   instance_class              = "db.t3.micro"


### PR DESCRIPTION
<img width="334" alt="Screenshot 2025-03-18 at 15 05 14" src="https://github.com/user-attachments/assets/f2c22581-cb86-4c8f-b267-2aa545ac4bf1" />

<img width="1286" alt="Screenshot 2025-03-18 at 15 08 09" src="https://github.com/user-attachments/assets/1233ed9a-f97f-46e1-aefe-94611328d20f" />

