### PR TITLE
pinned version to external-dns helm

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -214,7 +214,8 @@ deploy_external_dns() {
     --create-namespace \
     --set txtOwnerId=$application_name \
     --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=$external_dns_iam_role_arn \
-    --set domainFilters[0]=$certificate_domain
+    --set domainFilters[0]=$certificate_domain \
+    --version 1.15.2
   # Create a dashboard for Grafana with the metrics from the ServiceMonitor\
   kubectl apply -f ./k8s-configmaps/external-dns-grafana-dashboard.yaml -n external-dns
 }


### PR DESCRIPTION
Deployment of [PR 314](https://github.com/ministryofjustice/nvvs-devops-monitor/pull/314) failed due to the bug introduced in external-dns Chart version 1.16.0. 

https://github.com/ministryofjustice/nvvs-devops-monitor/actions/runs/14214768815/job/39828827208

As a fix, I am pinning the external-dns chart version to 1.15.2