### PR TITLE
updated slack channel for certificate-services

### DIFF
--- a/k8s-helm-charts/cns-team-monitoring/templates/alertmanager-primary-alertmanagerconfig.yaml
+++ b/k8s-helm-charts/cns-team-monitoring/templates/alertmanager-primary-alertmanagerconfig.yaml
@@ -192,7 +192,7 @@ spec:
             key: certificate_services_slack_webhook_url
             name: slack-webhooks
             optional: false
-          channel: '#mojo-staff-infrastructure-certificate-services-alerts'
+          channel: '#mojo-staff-certificate-services-alerts'
           sendResolved: true
           title: {{`'{{ template "slack.alerts.title" . }}'`}}
           text: {{`'{{ template "slack.alerts.text" . }}'`}}


### PR DESCRIPTION
Updated `certificate-services` channel from  `'#mojo-staff-infrastructure-certificate-services-alerts'` to `'#mojo-staff-certificate-services-alerts'`